### PR TITLE
fixed issues with localization in python after 3.11 upgrade

### DIFF
--- a/fanviddb/fanvids/schema.py
+++ b/fanviddb/fanvids/schema.py
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-from enum import Enum
+from enum import StrEnum
 from typing import List
 from typing import Optional
 
@@ -12,19 +12,19 @@ from pydantic import constr
 LanguageCode = constr(regex=r"[a-z]{2}-[A-Z]{2}")
 
 
-class StateEnum(str, Enum):
+class StateEnum(StrEnum):
     active = "active"
     deleted = "deleted"
 
 
-class RatingEnum(str, Enum):
+class RatingEnum(StrEnum):
     gen = "gen"
     teen = "teen"
     mature = "mature"
     explicit = "explicit"
 
 
-class ContentNotesEnum(str, Enum):
+class ContentNotesEnum(StrEnum):
     graphic_violence = "graphic-violence"
     major_character_death = "major-character-death"
     no_warnings_apply = "no-warnings-apply"
@@ -51,7 +51,7 @@ class Audio(BaseModel):
     languages: List[LanguageCode]  # type: ignore
 
 
-class UniqueIdentifierKind(str, Enum):
+class UniqueIdentifierKind(StrEnum):
     filename = "filename"
     youtube = "youtube"
     vimeo = "vimeo"

--- a/fanviddb/i18n/schema.py
+++ b/fanviddb/i18n/schema.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class Locale(str, Enum):
+class Locale(StrEnum):
     en_US = "en-US"
     zh_CN = "zh-CN"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ fastapi-users-db-sqlalchemy==4.0.3
 fastapi-users==10.0.7
 fastapi==0.95.2
 flake8==4.0.1
-fluent.runtime==-0.4.0
+fluent.runtime==0.4.0
 fluent.syntax==0.19.0
 greenlet==3.0.1
 h11==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ anyio==3.6.2
 asgiref==3.5.0
 asyncpg==0.29.0
 async-timeout==4.0.3
-attrs==20.3.0
-babel==2.9.1
+attrs==23.1.0
+babel==2.13.1
 bcrypt==3.2.0
 black==22.1.0
 certifi==2023.7.22
@@ -20,8 +20,8 @@ fastapi-users-db-sqlalchemy==4.0.3
 fastapi-users==10.0.7
 fastapi==0.95.2
 flake8==4.0.1
-fluent.runtime==0.3.1
-fluent.syntax==0.18.1
+fluent.runtime==-0.4.0
+fluent.syntax==0.19.0
 greenlet==3.0.1
 h11==0.12.0
 httpcore==0.15.0
@@ -56,7 +56,7 @@ pytest-mock==3.7.0
 pytest==7.1.1
 python-dateutil==2.8.1
 python-multipart==0.0.5
-pytz==2021.1
+pytz==2023.3.post1
 requests==2.31.0
 rfc3986==1.5.0
 six==1.16.0


### PR DESCRIPTION
I initially thought this was somehow a problem with fluent but it turned out to be a change in how to do string enums in python 3.11. https://github.com/python/cpython/issues/100458 https://docs.python.org/3.11/library/enum.html#enum.StrEnum